### PR TITLE
[#5] Enable deployment on Kubernetes

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"

--- a/charts/wildfly-common/templates/_buildconfig-bootable-jar.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-bootable-jar.yaml
@@ -6,9 +6,10 @@ metadata:
   labels: {}
 spec:
   output:
+    {{- include "wildfly-common.buildconfig.pushSecret" . | nindent 4 -}}
     to:
-      kind: ImageStreamTag
-      name: {{ include "wildfly-common.appImageStreamTag" . }}
+      kind: {{ .Values.build.output.kind }}
+      name: {{ include "wildfly-common.appImage" . }}
   source:
     type: Git
     git:

--- a/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
@@ -2,13 +2,13 @@
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
-  name: {{ include "wildfly-common.appBuilderImage" . }}
+  name: {{ include "wildfly-common.appBuilderImageName" . }}
   labels: {}
 spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{ include "wildfly-common.appBuilderImage" . }}:latest
+      name: {{ include "wildfly-common.appBuilderImage" . }}
   runPolicy: Serial
   source:
     git:

--- a/charts/wildfly-common/templates/_buildconfig-s2i.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i.yaml
@@ -6,15 +6,16 @@ metadata:
   labels: {}
 spec:
   output:
+    {{- include "wildfly-common.buildconfig.pushSecret" . | nindent 4 -}}
     to:
-      kind: ImageStreamTag
-      name: {{ include "wildfly-common.appImageStreamTag" . }}
+      kind: {{ .Values.build.output.kind }}
+      name: {{ include "wildfly-common.appImage" . }}
   source:
     type: Docker
     images:
     - from:
         kind: ImageStreamTag
-        name: {{ include "wildfly-common.appBuilderImage" . }}:latest
+        name: {{ include "wildfly-common.appBuilderImage" . }}
       paths:
       - destinationDir: .
         sourcePath: /s2i-output/server/
@@ -27,7 +28,7 @@ spec:
   - imageChange:
       from:
         kind: ImageStreamTag
-        name: {{ include "wildfly-common.appBuilderImage" . }}:latest
+        name: {{ include "wildfly-common.appBuilderImage" . }}
     type: ImageChange
   - type: ConfigChange
 {{ end }}

--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -1,25 +1,29 @@
-{{- define "wildfly-common.deploymentconfig.tpl" -}}
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+{{- define "wildfly-common.deployment.tpl" -}}
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: {{ include "wildfly-common.appName" . }}
   labels: {}
+  {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") }}
+  annotations:
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from":{
+            "kind":"ImageStreamTag",
+            "name":"{{ include "wildfly-common.appImage" . }}"
+          },
+          "fieldPath":"spec.template.spec.containers[0].image"
+        }
+      ]
+  {{- end }}
 spec:
   strategy:
     type: Recreate
-  triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - {{ include "wildfly-common.appName" . }}
-        from:
-          kind: ImageStreamTag
-          name: {{ include "wildfly-common.appImageStreamTag" . }}
-    - type: ConfigChange
   replicas: {{ .Values.deploy.replicas }}
   selector:
-    {{- include "wildfly-common.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "wildfly-common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       name: {{ include "wildfly-common.appName" . }}
@@ -31,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "wildfly-common.appName" . }}
-          image: {{ include "wildfly-common.appImageStreamTag" . }}
+          image: {{ include "wildfly-common.appImage" . }}
           imagePullPolicy: Always
           ports:
           - name: jolokia
@@ -91,6 +95,6 @@ spec:
       {{- end }}
 {{ end }}
 
-{{- define "wildfly-common.deploymentconfig" -}}
-{{- include "wildfly-common.util.merge" (append . "wildfly-common.deploymentconfig.tpl") -}}
+{{- define "wildfly-common.deployment" -}}
+{{- include "wildfly-common.util.merge" (append . "wildfly-common.deployment.tpl") -}}
 {{- end -}}

--- a/charts/wildfly-common/templates/_helpers.tpl
+++ b/charts/wildfly-common/templates/_helpers.tpl
@@ -15,24 +15,31 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-wildfly-common.appImage is the name of the application image that is built/deployed
+wildfly-common.appImageName is the name of the application image that is built/deployed
 */}}
-{{- define "wildfly-common.appImage" -}}
+{{- define "wildfly-common.appImageName" -}}
 {{ default (include "wildfly-common.appName" .) .Values.image.name }}
 {{- end -}}
 
 {{/*
-wildfly-common.appImageStreamTag is image stream of of the application image that is built/deployed
+wildfly-common.appImage is the name:tag of the application image of of the application image that is built/deployed
 */}}
-{{- define "wildfly-common.appImageStreamTag" -}}
-{{ include "wildfly-common.appImage" . }}:{{ .Values.image.tag}}
+{{- define "wildfly-common.appImage" -}}
+{{ include "wildfly-common.appImageName" . }}:{{ .Values.image.tag}}
 {{- end -}}
 
 {{/*
-wildfly.appBuilderImage corresponds to the imagestram for the application Builder image
+wildfly.appBuilderImageName corresponds to the name of the application Builder image
+*/}}
+{{- define "wildfly-common.appBuilderImageName" -}}
+{{ include "wildfly-common.appImageName" . }}-build-artifacts
+{{- end }}
+
+{{/*
+wildfly.appBuilderImage is the name:tag of the application Builder image
 */}}
 {{- define "wildfly-common.appBuilderImage" -}}
-{{ include "wildfly-common.appImage" . }}-build-artifacts
+{{ include "wildfly-common.appBuilderImageName" . }}:{{ .Values.image.tag}}
 {{- end }}
 
 {{/*
@@ -99,6 +106,20 @@ pullSecret:
   name: {{ .Values.build.pullSecret }}
 {{ else }}
 {{ fail (printf "Secret '%s' to pull images does not exist." .Values.build.pullSecret) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image push secret to push the application image
+*/}}
+{{- define "wildfly-common.buildconfig.pushSecret" -}}
+{{- if and .Values.build.output.pushSecret (eq .Values.build.output.kind "DockerImage") -}}
+{{- if lookup "v1" "Secret" .Release.Namespace .Values.build.output.pushSecret -}}
+pushSecret:
+  name: {{ .Values.build.output.pushSecret }}
+{{- else }}
+{{- fail (printf "Secret '%s' to push the application image does not exist." .Values.build.output.pushSecret) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/wildfly-common/templates/_imagestream-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_imagestream-s2i-build-artifacts.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: {{ include "wildfly-common.appBuilderImage" . }}
+  name: {{ include "wildfly-common.appBuilderImageName" . }}
   labels: {}
 {{- end -}}
 

--- a/charts/wildfly-common/templates/_imagestream.yaml
+++ b/charts/wildfly-common/templates/_imagestream.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: {{ include "wildfly-common.appImage" . }}
+  name: {{ include "wildfly-common.appName" . }}
   labels: {}
 {{- end -}}
 

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.
@@ -16,5 +16,5 @@ icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
 
 dependencies:
 - name: wildfly-common
-  version: 1.0.0
+  version: 1.1.0
   repository: file://../wildfly-common

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -18,11 +18,28 @@ oc create secret docker-registry my-pull-secret --docker-server=$REGISTRY_URL --
 ```
 
 You can use this secret by passing `--set build.pullSecret=my-pull-secret` to `helm install`, or you can configure this in a values file:
+
 ```yaml
 build:
   pullSecret: my-pull-secret
 ```
-and apply by passing `-f $VALUES_FILE`.
+
+### Push Secret
+
+You will need to create a push secret if you want to push your image to an external registry. Use the following command as a reference to create your push secret:
+
+```bash
+oc create secret docker-registry my-push-secret --docker-server=$SERVER_URL --docker-username=$USERNAME --docker-password=$PASSWORD --docker-email=$EMAIL
+```
+
+You can use this secret by passing `--set build.output.pushSecret=my-push-secret` and `--set build.output.kind=DockerImage`, or you can configure these in a values file:
+
+```yaml
+build:
+  output:
+    kind: DockerImage
+    pushSecret: my-push-secret
+```
 
 ## Application Image
 
@@ -43,6 +60,8 @@ The configuration to build the application image is configured in a `build` sect
 | `build.uri` | Git URI that references your git repo | &lt;required&gt; | Be sure to specify this to build the application. |
 | `build.ref` | Git ref containing the application you want to build | `main` | - |
 | `build.contextDir` | The sub-directory where the application source code exists | - | - |
+| `build.output.kind`|	Determines if the image will be pushed to an `ImageStreamTag` or a `DockerImage` | `ImageStreamTag` | [OpenShift Documentation](https://docs.openshift.com/container-platform/4.6/builds/managing-build-output.html) |
+| `build.output.pushSecret` | Push secret name | - | The secret must exist in the same namespace or the chart will fail to install - Used only if `build.output.kind` is `DockerImage` |
 | `build.pullSecret` | Image pull secret | - | The secret must exist in the same namespace or the chart will fail to install - [OpenShift documentation](https://docs.openshift.com/container-platform/latesst/openshift_images/managing_images/using-image-pull-secrets.html) |
 | `build.mode` | Determines whether the application will be built using WildFly S2I images or Bootable Jar | `s2i` | Allowed values: `s2i` or `bootable-jar` |
 | `build.env` | Freeform `env` items | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/). These environment variables will be used when the application is _built_. If you need to specify environment variables for the running application, use `deploy.env` instead. |

--- a/charts/wildfly/templates/deployment.yaml
+++ b/charts/wildfly/templates/deployment.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.deploy.enabled }}
-{{- include "wildfly-common.deploymentconfig" (list . "wildfly.deploymentconfig") -}}
+{{- include "wildfly-common.deployment" (list . "wildfly.deployment") -}}
 {{- end -}}
 
-{{ define "wildfly.deploymentconfig" }}
+{{ define "wildfly.deployment" }}
 {{- include "wildfly.metadata.labels" . }}
 spec:
   template:

--- a/charts/wildfly/templates/imagestream.yaml
+++ b/charts/wildfly/templates/imagestream.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.build.enabled -}}
+{{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") -}}
 {{- include "wildfly-common.imagestream" (list . "wildfly.metadata.labels") }}
 
 {{- if eq .Values.build.mode "s2i" }}

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -43,6 +43,22 @@
                     "description": "Context directory within your Git repo to use as the root for the build",
                     "type": ["string", "null"]
                 },
+                "output": {
+                  "description": "Configuration for the built application image",
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "description": "Determines where the application images will be pushed",
+                      "type": "string",
+                      "enum": ["ImageStreamTag", "DockerImage"],
+                      "default": "ImageStreamTag"
+                    },
+                    "pushSecret": {
+                      "description": "Name of the Push Secret",
+                      "type": ["string", "null"]
+                    }
+                  }
+                },
                 "env": {
                     "description": "List of environment variables to set in the container. Cannot be updated.",
                     "items": {

--- a/charts/wildfly/values.yaml
+++ b/charts/wildfly/values.yaml
@@ -8,6 +8,8 @@ build:
   s2i:
     builderImage: quay.io/wildfly/wildfly-centos7
     runtimeImage: quay.io/wildfly/wildfly-runtime-centos7
+  output:
+    kind: "ImageStreamTag"
   triggers: {}
 deploy:
   enabled: true

--- a/examples/microprofile-config/README.adoc
+++ b/examples/microprofile-config/README.adoc
@@ -1,0 +1,97 @@
+# Install a MicroProfile Application
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+:keywords:          openshift,wildfly,microprofile,helm
+
+This example shows how to deploy an Eclipse MicroProfile application with WildFly on OpenShift.
+
+## Prerequisites
+
+## Source Code
+
+The source code for the backend is hosted at https://github.com/wildfly/quickstart/tree/master/microprofile-config
+
+It is a simple MicroProfile application that uses JAX-RS to exposes HTTP endpoints that displays text configured with MicroProfile Config.
+
+When the application is deployed on OpenShift, it uses the `CONFIG_PROP` environment variable as the source of its config property.
+This environment variable is specified in the `deploy.env` section of the Helm Chart.
+
+## Installation
+
+The application can be built with Bootable Jar or using WildFly S2I images.
+
+### Installation with Bootable Jar
+
+The application can be compiled as a Bootable Jar.
+In that case, the Helm Chart is configured with `build.mode=bootable-jar`.
+
+[source,options="nowrap"]
+----
+$ helm install microprofile-config-app -f examples/microprofile-config/microprofile-config.yaml ./charts/wildfly
+----
+
+### Installation with WildFly S2I
+
+Alternatively, the application can be compiled and built using WildFly S2I images.
+In that case, the Helm Chart is configured with `build.mode` set to `s2i` and the chart also specifies which Galleon layers to provision:
+
+[source,yaml,options="nowrap"]
+---
+build:
+  mode: s2i
+  s2i:
+    galleonLayers: 'jaxrs-server,microprofile-platform'
+---
+
+The `microprofile-config-s2i.yaml` file contains the S2I configuration to build the application.
+
+[source,options="nowrap"]
+----
+$ helm install microprofile-config-app -f examples/microprofile-config/microprofile-config-s2i.yaml ./charts/wildfly
+----
+
+## Deployment
+
+Once the chart is installed, let's wait for the application to be built and deployed:
+
+[source,options="nowrap"]
+----
+$ oc get deployment/microprofile-config-app -w
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+microprofile-config-app   0/1     1            0           27s
+...
+microprofile-config-app   1/1     1            1           5m29s
+----
+
+## Use the application
+
+Once the application is deployed on OpenShift, it can be accessed from the route `microprofile-config-app`.
+Let's find the host that we can use to connect to this backend:
+
+[source,options="nowrap"]
+----
+$ oc get route microprofile-config-app -o jsonpath="{.spec.host}"
+microprofile-config-app-jmesnil1-dev.apps.sandbox.x8i5.p1.openshiftapps.com
+----
+
+This value will be different for every installation of the application.
+
+We can then query this application by calling one of its HTTP endpoints:
+
+[source,options="nowrap"]
+----
+$ curl -L $(oc get route microprofile-config-app -o jsonpath="{.spec.host}")/config/value
+Hello from OpenShift%
+----
+
+## Clean up
+
+The application can be deleted by running the command:
+
+[source,options="nowrap"]
+----
+$ helm delete microprofile-config-app
+release "microprofile-config-app" uninstalled
+----

--- a/examples/microprofile-config/microprofile-config-app-s2i.yaml
+++ b/examples/microprofile-config/microprofile-config-app-s2i.yaml
@@ -12,7 +12,7 @@ build:
   - name: MAVEN_OPTS
     value: '-XX:MetaspaceSize=251m -XX:MaxMetaspaceSize=256m'
 deploy:
-  replicas: 3
+  replicas: 1
   env:
   - name: CONFIG_PROP
     value: Hello from OpenShift

--- a/examples/microprofile-config/microprofile-config-app.yaml
+++ b/examples/microprofile-config/microprofile-config-app.yaml
@@ -1,5 +1,3 @@
-image:
-  name: wildfly-app
 build:
   uri: https://github.com/wildfly/quickstart.git
   ref: 22.0.1.Final


### PR DESCRIPTION
* Switch from `DeploymentConfig` to `Deployment`
* Add build.output.kind and build.output.pushSecret to be able to build
an application image and push it to a Docker registry

This fixes #5

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>