### PR TITLE
[#10] Fix default value for build.mode

### DIFF
--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -29,7 +29,7 @@
                     "description": "Which mode to use to build the application",
                     "type": "string",
                     "enum": ["s2i", "bootable-jar"],
-                    "default": "bootable-jar"
+                    "default": "s2i"
                 },
                 "uri": {
                     "description": "URI of GitHub repository",


### PR DESCRIPTION
The correct default value in the schema is set to s2i.

* Bump the wildfly's version to 1.2.0

This fixes #10.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>