### PR TITLE
[#17] Use arrays to configure galleon layers

### DIFF
--- a/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if .Values.build.s2i }}
       {{- if .Values.build.s2i.galleonLayers }}
       - name: GALLEON_PROVISION_LAYERS
-        value: {{ quote .Values.build.s2i.galleonLayers }}
+        value: {{ join "," .Values.build.s2i.galleonLayers | quote }}
       {{- end }}
       {{- end }}
       {{- if .Values.build.env }}

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -73,7 +73,7 @@ The configuration to build the application image is configured in a `build` sect
 | `build.s2i.version` | Version of the WildFly S2I images. | Defaults to this chart `AppVersion` | - |
 | `build.s2i.builderImage` | WildFly S2I Builder image | [quay.io/wildfly/wildfly-centos7](https://quay.io/wildfly/wildfly-centos7) | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i)  |
 | `build.s2i.runtimeImage` | WildFly S2I Runtime image | [quay.io/wildfly/wildfly-runtime-centos7](https://quay.io/wildfly/wildfly-runtime-centos7) | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) |
-| `build.s2i.galleonLayers` | A comma separated list of layer names to compose a WildFly server | - |  [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) |
+| `build.s2i.galleonLayers` | A list of layer names to compose a WildFly server | - | The value can be be either a `string` with a list of comma-separated layers or an array where each item is a layer - [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) |
 | `build.bootableJar.builderImage` | JDK Builder image for Bootable Jar | [registry.access.redhat.com/ubi8/openjdk-11:latest](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?gti-tabs=unauthenticated) | - |
 
 

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -234,8 +234,11 @@
                             "type": ["string", "null"]
                         },
                         "galleonLayers": {
-                            "description": "List of Galleon Layers to provisions (separated by commas)",
-                            "type": ["string", "null"]
+                            "description": "List of Galleon Layers to provision",
+                            "type": ["string", "array", "null"],
+                            "items": {
+                              "type": "string"
+                            }
                         }
                     }
                 },

--- a/examples/microprofile-config/README.adoc
+++ b/examples/microprofile-config/README.adoc
@@ -42,7 +42,9 @@ In that case, the Helm Chart is configured with `build.mode` set to `s2i` and th
 build:
   mode: s2i
   s2i:
-    galleonLayers: 'jaxrs-server,microprofile-platform'
+    galleonLayers:
+      - jaxrs-server
+      - microprofile-platform
 ---
 
 The `microprofile-config-s2i.yaml` file contains the S2I configuration to build the application.

--- a/examples/microprofile-config/microprofile-config-app-s2i.yaml
+++ b/examples/microprofile-config/microprofile-config-app-s2i.yaml
@@ -3,7 +3,9 @@ build:
   uri: https://github.com/wildfly/quickstart.git
   ref: 23.0.0.Final
   s2i:
-    galleonLayers: 'jaxrs-server,microprofile-platform'
+    galleonLayers:
+    - jaxrs-server
+    - microprofile-platform
   env:
   - name: ARTIFACT_DIR
     value: microprofile-config/target

--- a/examples/todo-backend/todo-backend-s2i.yaml
+++ b/examples/todo-backend/todo-backend-s2i.yaml
@@ -4,7 +4,10 @@ build:
   uri: https://github.com/wildfly/quickstart.git
   mode: s2i
   s2i:
-    galleonLayers: cloud-server,postgresql-datasource,ejb
+    galleonLayers:
+      - cloud-server
+      - postgresql-datasource
+      - ejb
   env:
     - name: ARTIFACT_DIR
       value: todo-backend/target


### PR DESCRIPTION
It remains possible to use a string with a comma-separated list of
layers.

This fixes #17

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>