### PR TITLE
[#16] Support Galleon dir and additional feature-packs

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 1.2.0
+version: 1.3.0
 appVersion: "1.0.0"

--- a/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
@@ -37,6 +37,14 @@ spec:
       - name: GALLEON_PROVISION_LAYERS
         value: {{ join "," .Values.build.s2i.galleonLayers | quote }}
       {{- end }}
+      {{- if .Values.build.s2i.featurePacks }}
+      - name: GALLEON_PROVISION_FEATURE_PACKS
+        value: {{ join "," .Values.build.s2i.featurePacks | quote }}
+      {{- end }}
+      {{- if .Values.build.s2i.galleonDir }}
+      - name: GALLEON_DIR
+        value: {{ quote .Values.build.s2i.galleonDir }}
+      {{- end }}
       {{- end }}
       {{- if .Values.build.env }}
       {{- tpl (toYaml .Values.build.env) . | nindent 6 }}

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.
@@ -16,5 +16,5 @@ icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
 
 dependencies:
 - name: wildfly-common
-  version: 1.2.0
+  version: 1.3.0
   repository: file://../wildfly-common

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -73,6 +73,8 @@ The configuration to build the application image is configured in a `build` sect
 | `build.s2i.version` | Version of the WildFly S2I images. | Defaults to this chart `AppVersion` | - |
 | `build.s2i.builderImage` | WildFly S2I Builder image | [quay.io/wildfly/wildfly-centos7](https://quay.io/wildfly/wildfly-centos7) | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i)  |
 | `build.s2i.runtimeImage` | WildFly S2I Runtime image | [quay.io/wildfly/wildfly-runtime-centos7](https://quay.io/wildfly/wildfly-runtime-centos7) | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) |
+| `build.s2i.galleonDir` | Directory relative to the root directory for the build that contains custom content for Galleon. | - | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) - since WildFly 23.0.2|
+| `build.s2i.featurePacks` | List of additional Galleon feature-packs identified by Maven coordinates (`<groupId>:<artifactId>:<version>`) | - | The value can be be either a `string` with a list of comma-separated Maven coordinate or an array where each item is the Maven coordinate of a feature pack - [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) - since WildFly 23.0.2|
 | `build.s2i.galleonLayers` | A list of layer names to compose a WildFly server | - | The value can be be either a `string` with a list of comma-separated layers or an array where each item is a layer - [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) |
 | `build.bootableJar.builderImage` | JDK Builder image for Bootable Jar | [registry.access.redhat.com/ubi8/openjdk-11:latest](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?gti-tabs=unauthenticated) | - |
 

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -233,6 +233,17 @@
                             "description": "Name of WildFly Runtime image",
                             "type": ["string", "null"]
                         },
+                        "featurePacks": {
+                          "description": "List of additional Galleon feature-packs identified by Maven coordinates (`<groupId>:<artifactId>:<version>`)",
+                          "type": ["string", "array", "null"],
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "galleonDir": {
+                          "description": "Directory relative to the root directory for the build that contains custom content for Galleon.",
+                          "type": ["string", "null"]
+                        },
                         "galleonLayers": {
                             "description": "List of Galleon Layers to provision",
                             "type": ["string", "array", "null"],
@@ -240,6 +251,7 @@
                               "type": "string"
                             }
                         }
+                      }
                     }
                 },
                 "bootableJar": {


### PR DESCRIPTION
For consistency with build.s2i.galleonLayers, build.s2i.featurePacks can
be either a CSV string or an array of strings.

this fixes #16.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>