### PR TITLE
Update Galleon Layers for todo-backend S2I example

### DIFF
--- a/examples/todo-backend/todo-backend-s2i.yaml
+++ b/examples/todo-backend/todo-backend-s2i.yaml
@@ -7,7 +7,6 @@ build:
     galleonLayers:
       - cloud-server
       - postgresql-datasource
-      - ejb-lite
   env:
     - name: ARTIFACT_DIR
       value: todo-backend/target


### PR DESCRIPTION
Use `cloud-server` layer that contains all required dependencies
to buil a JAX-RS + JPA + CDI application. There is no need to add the
`ejb` or `ejb-lite` layer

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>