### PR TITLE
[#26] Register wildfly chart on artifacthub.io

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,20 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: f62d89fb-9b79-43d8-8bf4-a5a4ca964847
+owners: # (optional, used to claim repository ownership)
+  - name: Jeff Mesnil
+    email: jmesnil@redhat.com
+  - name: Brian Stansberry
+    email: brian.stansberry@redhat.com
+ignore: # (optional, packages that should not be indexed by Artifact Hub)
+  - name: wildfly-common
+


### PR DESCRIPTION
Add the artifacthub-repo.yml to claim ownership fo the wildfly chart and
be flagged as a verified publisher. 

This fixes #26

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>