### PR TITLE
[#29] Upgrade to WildFly 24.0

### DIFF
--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.3.0
+version: 1.4.0
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.
-appVersion: "23.0"
+appVersion: "24.0"
 
 maintainers:
   - email: wildfly-dev@lists.jboss.org

--- a/examples/microprofile-config/microprofile-config-app-s2i.yaml
+++ b/examples/microprofile-config/microprofile-config-app-s2i.yaml
@@ -1,7 +1,7 @@
 build:
   mode: s2i
   uri: https://github.com/wildfly/quickstart.git
-  ref: 23.0.2.SP1
+  ref: 24.0.0.SP1
   s2i:
     galleonLayers:
     - jaxrs-server

--- a/examples/microprofile-config/microprofile-config-app.yaml
+++ b/examples/microprofile-config/microprofile-config-app.yaml
@@ -1,6 +1,6 @@
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 23.0.2.SP1
+  ref: 24.0.0.SP1
   mode: bootable-jar
   env:
   - name: ARTIFACT_DIR

--- a/examples/todo-backend/todo-backend-bootable-jar.yaml
+++ b/examples/todo-backend/todo-backend-bootable-jar.yaml
@@ -2,7 +2,7 @@
 # quickstart on OpenShift with the Helm Chart for WildFly.
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 23.0.2.SP1
+  ref: 24.0.0.SP1
   mode: bootable-jar
   env:
     - name: ARTIFACT_DIR

--- a/examples/todo-backend/todo-backend-s2i.yaml
+++ b/examples/todo-backend/todo-backend-s2i.yaml
@@ -2,7 +2,7 @@
 # quickstart on OpenShift with the Helm Chart for WildFly.
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 23.0.2.SP1
+  ref: 24.0.0.SP1
   mode: s2i
   s2i:
     galleonLayers:


### PR DESCRIPTION
* Bum the version to 1.4.0
* Bump the appVersion to `24.0`
* Update the examples to use the 24.0.0.SP1 tag from the quickstarts

This fixes #29

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>