### PR TITLE
WildFly 26 release

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -23,8 +23,4 @@ jobs:
 
             echo "Check Yaml Examples"
             shopt -s globstar
-            for f in examples/**/*.yaml; do # Whitespace-safe and recursive
-              echo -n "$f"
-              yq validate $f
-              echo "...✅"
-            done
+            yq eval-all 'true' examples/**/*.yaml > /dev/null

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.5.2
+version: 1.5.3
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.
-appVersion: "25.0"
+appVersion: "26.0"
 
 kubeVersion: ">= 1.19.0"
 home: https://wildfly.org

--- a/examples/microprofile-config/microprofile-config-app-s2i.yaml
+++ b/examples/microprofile-config/microprofile-config-app-s2i.yaml
@@ -1,18 +1,12 @@
 build:
   mode: s2i
   uri: https://github.com/wildfly/quickstart.git
-  ref: 25.0.0.Final
+  ref: 26.0.0.Final
+  contextDir: microprofile-config
   s2i:
     galleonLayers:
     - jaxrs-server
     - microprofile-platform
-  env:
-  - name: ARTIFACT_DIR
-    value: microprofile-config/target
-  - name: MAVEN_ARGS_APPEND
-    value: -am -pl microprofile-config
-  - name: MAVEN_OPTS
-    value: '-XX:MetaspaceSize=251m -XX:MaxMetaspaceSize=256m'
 deploy:
   replicas: 1
   env:

--- a/examples/microprofile-config/microprofile-config-app.yaml
+++ b/examples/microprofile-config/microprofile-config-app.yaml
@@ -1,17 +1,14 @@
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 25.0.0.Final
+  ref: 26.0.0.Final
+  contextDir: microprofile-config
   mode: bootable-jar
   env:
-  - name: ARTIFACT_DIR
-    value: microprofile-config/target
   - name: MAVEN_ARGS_APPEND
     # Use the bootable-jar-openshift profile to ensure that the application
     # can be deployed on OpenShift but disable JKube as the image will be 
     # built and deployed by this chart.
-    value: -am -pl microprofile-config -Pbootable-jar-openshift -Djkube.skip=true
-  - name: MAVEN_OPTS
-    value: '-XX:MetaspaceSize=251m -XX:MaxMetaspaceSize=256m'
+    value: -Pbootable-jar-openshift -Djkube.skip=true
 deploy:
   replicas: 1
   env:

--- a/examples/todo-backend/todo-backend-bootable-jar.yaml
+++ b/examples/todo-backend/todo-backend-bootable-jar.yaml
@@ -2,15 +2,12 @@
 # quickstart on OpenShift with the Helm Chart for WildFly.
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 25.0.0.Final
+  ref: 26.0.0.Final
+  contextDir: todo-backend
   mode: bootable-jar
   env:
-    - name: ARTIFACT_DIR
-      value: todo-backend/target
     - name: MAVEN_ARGS_APPEND
-      value: -am -pl todo-backend -P bootable-jar-openshift
-    - name: MAVEN_OPTS
-      value: '-XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m'
+      value: -P bootable-jar-openshift
 deploy:
   replicas: 3
   env:

--- a/examples/todo-backend/todo-backend-s2i.yaml
+++ b/examples/todo-backend/todo-backend-s2i.yaml
@@ -2,19 +2,13 @@
 # quickstart on OpenShift with the Helm Chart for WildFly.
 build:
   uri: https://github.com/wildfly/quickstart.git
-  ref: 25.0.0.Final
+  ref: 26.0.0.Final
+  contextDir: todo-backend
   mode: s2i
   s2i:
     galleonLayers:
       - cloud-server
       - postgresql-datasource
-  env:
-    - name: ARTIFACT_DIR
-      value: todo-backend/target
-    - name: MAVEN_ARGS_APPEND
-      value: -am -pl todo-backend
-    - name: MAVEN_OPTS
-      value: '-XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m'
 deploy:
   replicas: 3
   env:


### PR DESCRIPTION
* bump wildfly appVersion to 26.0 and version to 1.5.3
* refactor examples now that quickstarts can be built without requiring
  to build their parent module first.