### PR TITLE
Helm Charts 2.0.0 for WildFly

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 1.4.1
-appVersion: "1.0.0"
+version: 2.0.0

--- a/charts/wildfly-common/templates/_buildconfig-s2i.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i.yaml
@@ -18,7 +18,7 @@ spec:
         name: {{ include "wildfly-common.appBuilderImage" . }}
       paths:
       - destinationDir: .
-        sourcePath: /s2i-output/server/
+        sourcePath: /opt/server
   strategy:
     dockerStrategy:
       {{- include "wildfly-common.buildconfig.pullSecret" . | nindent 6 -}}

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,11 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.5.4
-
-# This is the version number of the application being deployed.
-# This maps to the WildFly S2I Images tag that is used for S2I build.
-appVersion: "26.0"
+version: 2.0.0
 
 kubeVersion: ">= 1.19.0"
 home: https://wildfly.org
@@ -23,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 1.4.1
+  version: 2.0.0
   repository: file://../wildfly-common

--- a/charts/wildfly/templates/_helpers.tpl
+++ b/charts/wildfly/templates/_helpers.tpl
@@ -2,22 +2,15 @@
 wildfly.builderImage corresponds to the name of the WildFly Builder Image
 */}}
 {{- define "wildfly.builderImage" -}}
-{{ .Values.build.s2i.builderImage }}:{{ include "wildfly.version" . }}
+{{ .Values.build.s2i.builderImage }}
 {{- end }}
 
 {{/*
 wildfly.runtimeImage corresponds to the name of the WildFly Runtime Image
 */}}
 {{- define "wildfly.runtimeImage" -}}
-{{ .Values.build.s2i.runtimeImage }}:{{ include "wildfly.version" . }}
+{{ .Values.build.s2i.runtimeImage }}
 {{- end }}
-
-{{/*
-If wildfly.version is not defined, use by defaul the Chart's appVersion
-*/}}
-{{- define "wildfly.version" -}}
-{{- default .Chart.AppVersion .Values.build.s2i.version -}}
-{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
@@ -32,9 +25,6 @@ Common labels
 {{- define "wildfly.labels" -}}
 helm.sh/chart: {{ include "wildfly.chart" . }}
 {{ include "wildfly-common.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/wildfly/templates/buildconfig-s2i.yaml
+++ b/charts/wildfly/templates/buildconfig-s2i.yaml
@@ -8,11 +8,8 @@ spec:
   source:
     dockerfile: |-
       FROM {{ include "wildfly.runtimeImage" . }}
-      COPY /server $JBOSS_HOME
-      USER root
-      RUN chown -R jboss:root $JBOSS_HOME && chmod -R ug+rwX $JBOSS_HOME
-      USER jboss
-      CMD $JBOSS_HOME/bin/openshift-launch.sh
+      COPY --chown=jboss:root /server $JBOSS_HOME
+      RUN chmod -R ug+rwX $JBOSS_HOME
   strategy:
     dockerStrategy:
       from:

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -221,10 +221,6 @@
                     "description": "Configuration specific to S2I Build (applicable only if build mode is set to s2i)",
                     "type": ["object", "null"],
                     "properties": {
-                        "version": {
-                            "description": "WildFly version. If not specified, the Helm's appVersion will be used instead.",
-                            "type": ["string", "null"]
-                        },
                         "builderImage": {
                             "description": "Name of WildFly Builder image",
                             "type": ["string", "null"]

--- a/charts/wildfly/values.yaml
+++ b/charts/wildfly/values.yaml
@@ -6,8 +6,8 @@ build:
   bootableJar:
     builderImage: registry.access.redhat.com/ubi8/openjdk-11:latest
   s2i:
-    builderImage: quay.io/wildfly/wildfly-centos7
-    runtimeImage: quay.io/wildfly/wildfly-runtime-centos7
+    builderImage: quay.io/wildfly/wildfly-s2i-jdk11:latest
+    runtimeImage: quay.io/wildfly/wildfly-runtime-jdk11:latest
   output:
     kind: "ImageStreamTag"
   triggers: {}

--- a/examples/microprofile-config/README.adoc
+++ b/examples/microprofile-config/README.adoc
@@ -7,7 +7,8 @@
 
 This example shows how to deploy an Eclipse MicroProfile application with WildFly on OpenShift.
 
-## Prerequisites
+[WARNING]
+This example is using the `wildfly-chart` 1.x. They are not compatible with the `wildfly-chart` 2.x
 
 ## Source Code
 

--- a/examples/todo-backend/README.adoc
+++ b/examples/todo-backend/README.adoc
@@ -9,6 +9,9 @@
 The `todo-backend` quickstart demonstrates how to implement a backend that exposes a HTTP API with JAX-RS
 to manage a list of ToDo which are persisted in a database with JPA.
 
+[WARNING]
+This example is using the `wildfly-chart` 1.x. They are not compatible with the `wildfly-chart` 2.x
+
 This quickstart shows how to setup a local deployment of this backend as well as a deployment on OpenShift to connect
 to a PostgreSQL database also hosted on OpenShift.
 


### PR DESCRIPTION
This major version relies on the new S2I images
for WildFly and the use of the wildfly-maven-plugin to
provision a server.

This major version will *not* work with older WildFly S2I images (from
https://quay.io/wildfly/wildfly-centos7)

* Set Chart's version to 2.0.0.
* Remove Chart's appVersion (as the WildFly version is no longer computed by the
  Helm Chart)
* Update S2I BuildConfig to update the S2I output to /opt/server
* Remove build.s2i.version version
* Update build.s2i.builderImage & build.s2i.runtimeImage to point to the
   new S2I images (including the tag in the names)

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>