### PR TITLE
WildFly 26.1 release

### DIFF
--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 1.5.4
+version: 1.5.5
 
 # This is the version number of the application being deployed.
 # This maps to the WildFly S2I Images tag that is used for S2I build.
-appVersion: "26.0"
+appVersion: "26.1"
 
 kubeVersion: ">= 1.19.0"
 home: https://wildfly.org


### PR DESCRIPTION
Bump the appVersion to 26.1 after the release of the 26.1 S2I images
Bump the version to 1.5.5

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>