### PR TITLE
[#61] Allow prereleased version of Kubernetes

### DIFF
--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 2.0.0
+version: 2.0.1
 
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 home: https://wildfly.org
 
 maintainers:


### PR DESCRIPTION
* Update `kubeVersion` to allow installation on pre-released version of
Kubernetes (after 1.19)
* bump `version` to 2.0.1 to prepare next release

This fixes #61

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>