### PR TITLE
[#67] Add deployment labels and annotations

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 2.0.0
+version: 2.0.1

--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -4,8 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "wildfly-common.appName" . }}
   labels: {}
-  {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") }}
   annotations:
+  {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") }}
     image.openshift.io/triggers: |-
       [
         {
@@ -16,6 +16,9 @@ metadata:
           "fieldPath":"spec.template.spec.containers[0].image"
         }
       ]
+  {{- end }}
+  {{- if .Values.deploy.annotations }}
+    {{- tpl (toYaml .Values.deploy.annotations) . | nindent 4 }}
   {{- end }}
 spec:
   strategy:
@@ -28,6 +31,10 @@ spec:
     metadata:
       name: {{ include "wildfly-common.appName" . }}
       labels: {}
+      annotations:
+      {{- if .Values.deploy.annotations }}
+        {{- tpl (toYaml .Values.deploy.annotations) . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.deploy.initContainers }}
       initContainers:

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -19,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.0.0
+  version: 2.0.1
   repository: file://../wildfly-common

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -139,6 +139,7 @@ The configuration to build the application image is configured in a `deploy` sec
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |
+| `deploy.annotations` | Map of `string` annotations that are applied to the deployment and its pod's `template` | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
 | `deploy.enabled` | Determines if deployment-related resources should be created. | `true` | Set this to `false` if you do not want to deploy an application image built by this chart. |
 | `deploy.replicas` | Number of pod replicas to deploy. | `1` | [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html) | 
 | `deploy.route.enabled` | Determines if a `Route` should be created | `true` | Allows clients outside of OpenShift to access your application |
@@ -148,6 +149,7 @@ The configuration to build the application image is configured in a `deploy` sec
 | `deploy.env` | Freeform `env` items | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/).  These environment variables will be used when the application is _running_. If you need to specify environment variables when the application is built, use `build.env` instead. |
 | `deploy.envFrom` | Freeform `envFrom` items | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/).  These environment variables will be used when the application is _running_. If you need to specify environment variables when the application is built, use `build.envFrom` instead. |
 | `deploy.resources` | Freeform `resources` items | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| `deploy.labels` | Map of `string` labels that are applied to the deployment and its pod's `template` | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) |
 | `deploy.livenessProbe` | Freeform `livenessProbe` field. | HTTP Get on `<ip>:admin/health/live` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
 | `deploy.readinessProbe` | Freeform `readinessProbe` field. | HTTP Get on `<ip>:admin/health/ready` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
 | `deploy.startupProbe` | Freeform `startupProbe` field. | HTTP Get on `<ip>:admin/health/live` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |

--- a/charts/wildfly/templates/_helpers.tpl
+++ b/charts/wildfly/templates/_helpers.tpl
@@ -32,4 +32,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 metadata:
   labels:
   {{- include "wildfly.labels" . | nindent 4 }}
+{{- end }}
+
+{{- define "wildfly.deployment.labels" -}}
+metadata:
+  labels:
+  {{- include "wildfly.labels" . | nindent 4 }}
+  {{- if .Values.deploy.labels }}
+  {{- tpl (toYaml .Values.deploy.labels) . | nindent 4 }}
+  {{- end -}}
 {{- end -}}

--- a/charts/wildfly/templates/deployment.yaml
+++ b/charts/wildfly/templates/deployment.yaml
@@ -3,8 +3,8 @@
 {{- end -}}
 
 {{ define "wildfly.deployment" }}
-{{- include "wildfly.metadata.labels" . }}
+{{- include "wildfly.deployment.labels" . }}
 spec:
   template:
-    {{- include "wildfly.metadata.labels" . | nindent 4 }}
+    {{- include "wildfly.deployment.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -265,6 +265,13 @@
             "description": "Configuration to deploy the application",
             "type": "object",
             "properties": {
+              "annotations": {
+                "type": "object",
+                "description": "Annotations that are applied to the deployed application and its pods",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
                 "enabled": {
                     "description": "Enable/Disable deploying the application image",
                     "type": "boolean",
@@ -273,6 +280,13 @@
                 "replicas": {
                     "type": "integer",
                     "description": "Number of pod replicas to deploy"
+                },
+                "labels": {
+                  "type": "object",
+                  "description": "Labels that are applied to the deployed application and its pods",
+                  "additionalProperties": {
+                    "type":"string"
+                  }
                 },
                 "resources": {
                     "description": "Freeform resources requirements to deploy the application image"

--- a/examples/microprofile-config/microprofile-config-app-s2i.yaml
+++ b/examples/microprofile-config/microprofile-config-app-s2i.yaml
@@ -4,11 +4,18 @@ build:
   ref: 26.0.0.Final
   contextDir: microprofile-config
   s2i:
+    featurePacks:
+      - org.wildfly:wildfly-galleon-pack:26.1.1.Final
     galleonLayers:
-    - jaxrs-server
-    - microprofile-platform
+      - jaxrs-server
+      - microprofile-platform
 deploy:
   replicas: 1
   env:
-  - name: CONFIG_PROP
-    value: Hello from OpenShift
+    - name: CONFIG_PROP
+      value: Hello from OpenShift
+  annotations:
+    a8r.io/owner: wildfly.org
+    a8r.io/description: >-
+      This application demonstrates how to use MicroProfile Config to inject
+      configuration from OpenShift in the application.


### PR DESCRIPTION
* Add `deploy.labels` field to apply labels to the deployed application
  and its pod
* Add `deploy.annotations` field to apply annotations to the deployed
  application and its pod.
* Update microprofile-config-s2i quickstart to set the
  GALLEON_PROVISION_FEATURE_PACKS env var during build.

This fixes #67

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>