### PR TITLE
[#71] Add `deploy.route.host` field

### DIFF
--- a/charts/wildfly-common/templates/_route.yaml
+++ b/charts/wildfly-common/templates/_route.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     openshift.io/host.generated: 'true'
 spec:
+  {{- if .Values.deploy.route.host }}
+  host: {{ .Values.deploy.route.host }}
+  {{- end }}
   to:
     kind: Service
     name: {{ include "wildfly-common.appName" . }}

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -149,6 +149,7 @@ The configuration to build the application image is configured in a `deploy` sec
 | `deploy.enabled` | Determines if deployment-related resources should be created. | `true` | Set this to `false` if you do not want to deploy an application image built by this chart. |
 | `deploy.replicas` | Number of pod replicas to deploy. | `1` | [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html) | 
 | `deploy.route.enabled` | Determines if a `Route` should be created | `true` | Allows clients outside of OpenShift to access your application |
+| `deploy.route.host` | `host` is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen | - | [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html) |
 | `deploy.route.tls.enabled` | Determines if the `Route` should be TLS-encrypted | `true`| [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/networking/routes/secured-routes.html) |
 | `deploy.route.tls.termination` | Determines the type of TLS termination to use | `edge`| Allowed values: `edge, reencrypt, passthrough` |
 | `deploy.route.tls.insecureEdgeTerminationPolicy` | Determines if insecure traffic should be redirected | `Redirect` | Allowed values: `Allow, Disable, Redirect` |

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -488,6 +488,10 @@
                             "default": true,
                             "type": "boolean"
                         },
+                        "host": {
+                          "description": "alias/DNS that points to the service. If not specified a route name will typically be automatically chosen",
+                          "type": "string"
+                        },
                         "tls": {
                           "description": "TLS Configuration for the Route",
                           "type": "object",


### PR DESCRIPTION
If specified, the `deploy.route.host` field is used to set the host
alias for the `Route` resource created by the chart.

This fixes #71

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>