### PR TITLE
[#72] Add secure service for TLS support

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 2.0.1
+version: 2.0.2

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 2.0.2
+version: 2.0.3
 
 kubeVersion: ">= 1.19.0-0"
 home: https://wildfly.org
@@ -19,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.0.1
+  version: 2.0.2
   repository: file://../wildfly-common

--- a/charts/wildfly/values.yaml
+++ b/charts/wildfly/values.yaml
@@ -14,6 +14,7 @@ build:
 deploy:
   enabled: true
   replicas: 1
+  tls: {}
   route:
     enabled: true
     tls:


### PR DESCRIPTION
* add a `deploy.tls: {}` to the default values so that this field always
  exist.

* bump wildfly-common chart version to 2.0.2
* bump wildfly chart version to 2.0.3

This fixes #72.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>