### PR TITLE
[#89] Verify that secrets exist before installing the Helm Release

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 2.0.3
+version: 2.0.4

--- a/charts/wildfly-common/templates/_buildconfig-bootable-jar.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-bootable-jar.yaml
@@ -18,10 +18,7 @@ spec:
     {{- if .Values.build.contextDir }}
     contextDir: {{ .Values.build.contextDir }}
     {{- end }}
-    {{- if .Values.build.sourceSecret }}
-    sourceSecret:
-      name: {{ .Values.build.sourceSecret }}
-    {{- end }}
+    {{- include "wildfly-common.buildconfig.sourceSecret" . | nindent 4 -}}
     {{- if .Values.build.images }}
     images:
       {{- tpl (toYaml .Values.build.images) . | nindent 6 }}

--- a/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
@@ -17,10 +17,7 @@ spec:
     {{- if .Values.build.contextDir }}    
     contextDir: {{ .Values.build.contextDir }}
     {{- end }}
-    {{- if .Values.build.sourceSecret }}    
-    sourceSecret:
-      name: {{ .Values.build.sourceSecret }}
-    {{- end }}
+    {{- include "wildfly-common.buildconfig.sourceSecret" . | nindent 4 -}}
     {{- if .Values.build.images }}
     images:
       {{- tpl (toYaml .Values.build.images) . | nindent 6 }}

--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -40,10 +40,7 @@ spec:
       initContainers:
         {{- tpl (toYaml .Values.deploy.initContainers) . | nindent 8 }}
       {{- end }}
-      {{- if .Values.deploy.imagePullSecrets }}
-      imagePullSecrets:
-        {{- tpl (toYaml .Values.deploy.imagePullSecrets) . | nindent 8 }}
-      {{- end }}
+      {{- include "wildfly-common.deployment.imagePullSecrets" . | nindent 6 -}}
       containers:
         - name: {{ include "wildfly-common.appName" . }}
           image: {{ include "wildfly-common.appImage" . }}

--- a/charts/wildfly-common/templates/_helpers.tpl
+++ b/charts/wildfly-common/templates/_helpers.tpl
@@ -68,15 +68,12 @@ Trigger a build from GitHub Webhook
 */}}
 {{- define "wildfly-common.buildconfig.triggers.github" -}}
 {{- if .Values.build.triggers.githubSecret}}
-{{- if lookup "v1" "Secret" .Release.Namespace .Values.build.triggers.githubSecret }}
+{{- include "wildfly-common.secret.lookup" (list .Release.Namespace .Values.build.triggers.githubSecret "Secret '%s' for GitHub webhook does not exist.") -}}
 - type: "GitHub"
   github:
     secretReference:
       name: {{ quote .Values.build.triggers.githubSecret }}
-{{ else }}
-{{ fail (printf "Secret '%s' for GitHub webhook does not exist." .Values.build.triggers.githubSecret) }}
-{{- end }}
-{{- end }}
+{{ end }}
 {{- end }}
 
 {{/*
@@ -84,16 +81,13 @@ Trigger a build from Generic Webhook
 */}}
 {{- define "wildfly-common.buildconfig.triggers.generic" -}}
 {{- if .Values.build.triggers.genericSecret}}
-{{- if lookup "v1" "Secret" .Release.Namespace .Values.build.triggers.genericSecret }}
+{{- include "wildfly-common.secret.lookup" (list .Release.Namespace .Values.build.triggers.genericSecret "Secret '%s' for Generic webhook does not exist.") -}}
 - type: "Generic"
   generic:
     secretReference:
       name: {{ quote .Values.build.triggers.genericSecret }}
     allowEnv: true
-{{ else }}
-{{ fail (printf "Secret '%s' for Generic webhook does not exist." .Values.build.triggers.genericSecret) }}
-{{- end }}
-{{- end }}
+{{ end }}
 {{- end }}
 
 {{/*
@@ -101,13 +95,21 @@ Image pull secret to build the application image
 */}}
 {{- define "wildfly-common.buildconfig.pullSecret" -}}
 {{- if .Values.build.pullSecret}}
-{{- if lookup "v1" "Secret" .Release.Namespace .Values.build.pullSecret }}
+{{- include "wildfly-common.secret.lookup" (list .Release.Namespace .Values.build.pullSecret "Secret '%s' to pull images does not exist.") -}}
 pullSecret:
   name: {{ .Values.build.pullSecret }}
-{{ else }}
-{{ fail (printf "Secret '%s' to pull images does not exist." .Values.build.pullSecret) }}
+{{ end }}
 {{- end }}
-{{- end }}
+
+{{/*
+Source secret to pull the source code from a private Git repository
+*/}}
+{{- define "wildfly-common.buildconfig.sourceSecret" -}}
+{{- if .Values.build.sourceSecret}}
+{{- include "wildfly-common.secret.lookup" (list .Release.Namespace .Values.build.sourceSecret "Secret '%s' to pull the Git repository does not exist.") -}}
+sourceSecret:
+  name: {{ .Values.build.sourceSecret }}
+{{ end }}
 {{- end }}
 
 {{/*
@@ -115,11 +117,41 @@ Image push secret to push the application image
 */}}
 {{- define "wildfly-common.buildconfig.pushSecret" -}}
 {{- if and .Values.build.output.pushSecret (eq .Values.build.output.kind "DockerImage") -}}
-{{- if lookup "v1" "Secret" .Release.Namespace .Values.build.output.pushSecret -}}
+{{- include "wildfly-common.secret.lookup" (list .Release.Namespace .Values.build.output.pushSecret "Secret '%s' to push the application image does not exist.") -}}
 pushSecret:
   name: {{ .Values.build.output.pushSecret }}
-{{- else }}
-{{- fail (printf "Secret '%s' to push the application image does not exist." .Values.build.output.pushSecret) }}
+{{ end }}
 {{- end }}
+
+
+{{/*
+Image pull secrets to pull the application image during deployment.
+*/}}
+{{- define "wildfly-common.deployment.imagePullSecrets" -}}
+{{- if .Values.deploy.imagePullSecrets -}}
+{{- range .Values.deploy.imagePullSecrets }}
+  {{- include "wildfly-common.secret.lookup" (list $.Release.Namespace .name "Secret '%s' to pull the application image does not exist.") -}}
+{{- end }}
+imagePullSecrets:
+  {{- tpl (toYaml .Values.deploy.imagePullSecrets) . | nindent 2 }}
+{{ end }}
+{{- end }}
+
+
+{{/*
+Verify that a secret exists in the given namespace or fail with an error message
+
+This template needs 3 parameters in a list:
+1. The namespace of the secret
+2. the name of the secret
+3. the error message if the secret does not exist
+
+*/}}
+{{- define "wildfly-common.secret.lookup" -}}
+{{- $namespace := index . 0 -}}
+{{- $secret := index . 1 -}}
+{{- $failMessage := index . 2 -}}
+{{- if not (lookup "v1" "Secret" $namespace $secret) -}}
+{{- fail (printf $failMessage $secret) -}}
 {{- end }}
 {{- end }}

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -19,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.0.3
+  version: 2.0.4
   repository: file://../wildfly-common


### PR DESCRIPTION
Refactor the secret lookup so that it applies to all secrets expected by the Helm Chart

This fixes #89.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>