### PR TITLE
[#94] remove GALLEON_PROVISION_DEFAULT_FAT_SERVER build env var

### DIFF
--- a/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly-common/templates/_buildconfig-s2i-build-artifacts.yaml
@@ -29,8 +29,6 @@ spec:
       {{- include "wildfly-common.buildconfig.pullSecret" . | nindent 6 -}}
       from: {}
       env:
-      - name: GALLEON_PROVISION_DEFAULT_FAT_SERVER
-        value: "true"
       - name: CUSTOM_INSTALL_DIRECTORIES
         value: extensions
       {{- if .Values.build.s2i }}


### PR DESCRIPTION
This env var was required when the default server was thin but that is no longer the case.

This fixes #94.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>