### PR TITLE
[#93] Add the ability to skip building the application image

### DIFF
--- a/charts/wildfly-common/templates/_helpers.tpl
+++ b/charts/wildfly-common/templates/_helpers.tpl
@@ -32,8 +32,12 @@ wildfly-common.appImage is the name:tag of the application image of of the appli
 wildfly.appBuilderImageName corresponds to the name of the application Builder image
 */}}
 {{- define "wildfly-common.appBuilderImageName" -}}
+{{- if .Values.build.s2i.buildApplicationImage -}}
 {{ include "wildfly-common.appImageName" . }}-build-artifacts
-{{- end }}
+{{- else -}}
+{{ include "wildfly-common.appImageName" . }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 wildfly.appBuilderImage is the name:tag of the application Builder image

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -142,6 +142,7 @@ If the application image has been built by another mechanism, you can skip the b
 | `build.ref` | Git ref containing the application you want to build | `main` | - |
 | `build.resources` | Freeform `resources` items | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | `build.s2i` | Configuration specific to building with WildFly S2I images | - | - |
+| `build.s2i.buildApplicationImage` | Whether the application image is built. If `false` the Helm release will only create the builder image (and name it from the Helm release) | `true` | - |
 | `build.s2i.builderImage` | WildFly S2I Builder image | [quay.io/wildfly/wildfly-s2i-jdk11:latest](https://quay.io/repository/wildfly/wildfly-s2i-jdk11) | [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i)  |
 | `build.s2i.builderKind` | Determines the type of images for S2I Builder image (`DockerImage`, `ImageStreamTag` or `ImageStreamImage`) | the value of `build.s2i.kind` | (OKD Documentation](https://docs.okd.io/latest/cicd/|
 | `build.s2i.featurePacks` | *Deprecated* List of Galleon feature-packs identified by Maven coordinates (`<groupId>:<artifactId>:<version>`) | - | The value can be be either a `string` with a list of comma-separated Maven coordinate or an array where each item is the Maven coordinate of a feature pack - [WildFly S2I documentation](https://github.com/wildfly/wildfly-s2i) - since WildFly 23.0.2|

--- a/charts/wildfly/templates/buildconfig-s2i.yaml
+++ b/charts/wildfly/templates/buildconfig-s2i.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.build.enabled (eq .Values.build.mode "s2i") }}
+{{- if (and .Values.build.enabled (and (eq .Values.build.mode "s2i") .Values.build.s2i.buildApplicationImage)) }}
 {{- include "wildfly-common.buildconfig-s2i" (list . "wildfly.buildconfig-s2i") -}}
 {{- end -}}
 

--- a/charts/wildfly/templates/imagestream.yaml
+++ b/charts/wildfly/templates/imagestream.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") -}}
+
+{{- if .Values.build.s2i.buildApplicationImage -}}
 {{- include "wildfly-common.imagestream" (list . "wildfly.metadata.labels") }}
+{{- end -}}
 
 {{- if eq .Values.build.mode "s2i" }}
 ---

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -231,6 +231,11 @@
                           "enum": ["ImageStreamTag", "DockerImage", "ImageStreamImage"],
                           "default": "DockerImage"
                         },
+                        "buildApplicationImage": {
+                          "description": "Determine if the application image must be built. If false, the Helm release will  build the first artifact image (with the name of the Helm release)",
+                          "type": "boolean",
+                          "default": true
+                        },
                         "builderImage": {
                             "description": "Name of WildFly Builder image",
                             "type": ["string", "null"]

--- a/charts/wildfly/values.yaml
+++ b/charts/wildfly/values.yaml
@@ -9,6 +9,7 @@ build:
     kind: DockerImage
     builderImage: quay.io/wildfly/wildfly-s2i-jdk11:latest
     runtimeImage: quay.io/wildfly/wildfly-runtime-jdk11:latest
+    buildApplicationImage: true
   output:
     kind: ImageStreamTag
   triggers: {}


### PR DESCRIPTION
If `build.s2i.buildApplication` is set to `false`, the resources to create the applicaition image are not generated.
In that case, the builder-artifacts image will take over the name of the Helm release (as it is the only produced image).

Deployment of the builder image can still happen and needs to be explicitely disabled with `deploy.enabled` set to `false` if needs be.

This fixes #93

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>