### PR TITLE
[#106] Add annotation to link the deployment to its source code

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 2.1.0
+version: 2.1.1

--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -17,6 +17,12 @@ metadata:
         }
       ]
   {{- end }}
+  {{- if and .Values.build.enabled .Values.build.uri }}
+    app.openshift.io/vcs-uri:  {{ quote .Values.build.uri }}
+  {{- end }}
+  {{- if and .Values.build.enabled .Values.build.ref }}
+    app.openshift.io/vcs-ref:  {{ quote .Values.build.ref }}
+  {{- end }}
   {{- if .Values.deploy.annotations }}
     {{- tpl (toYaml .Values.deploy.annotations) . | nindent 4 }}
   {{- end }}

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 2.3.1
+version: 2.3.2
 
 kubeVersion: ">= 1.19.0-0"
 home: https://wildfly.org
@@ -19,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.1.0
+  version: 2.1.1
   repository: file://../wildfly-common


### PR DESCRIPTION
* add the app.openshift.io/vcs-uri (resp. app.openshift.io/vcs-ref) if build is enabled and the `build.uri` (resp. `build.ref`) field is defined.
* bump wildfly-common version to 2.1.1
* bump wildfly version to 2.3.2

This fixes #106.