### PR TITLE
[#106] Add annotation to link the deployment to its source code

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.0.0"

--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -4,8 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "wildfly-common.appName" . }}
   labels: {}
-  {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") }}
   annotations:
+  {{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") }}
     image.openshift.io/triggers: |-
       [
         {
@@ -16,6 +16,12 @@ metadata:
           "fieldPath":"spec.template.spec.containers[0].image"
         }
       ]
+  {{- end }}
+  {{- if and .Values.build.enabled .Values.build.uri }}
+    app.openshift.io/vcs-uri:  {{ quote .Values.build.uri }}
+  {{- end }}
+  {{- if and .Values.build.enabled .Values.build.ref }}
+    app.openshift.io/vcs-ref:  {{ quote .Values.build.ref }}
   {{- end }}
 spec:
   strategy:


### PR DESCRIPTION
* add the app.openshift.io/vcs-uri (resp. app.openshift.io/vcs-ref) if build is enabled and the `build.uri` (resp. `build.ref`) field is defined.
* Bump wildfly-common to 1.3.2

This fixes #106.