### PR TITLE
[#109] Update app.kubernetes.io/name label

### DIFF
--- a/charts/wildfly-common/templates/_helpers.tpl
+++ b/charts/wildfly-common/templates/_helpers.tpl
@@ -59,7 +59,7 @@ If release name contains chart name it will be used as a full name.
 Selector labels
 */}}
 {{- define "wildfly-common.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "wildfly-common.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 


### PR DESCRIPTION
Set it to the name of the Release (instead of the name of the Helm Chart).

This fixes #109.