### PR TITLE
Make the build step of the Helm Chart conditional on OpenShift resources

### DIFF
--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -127,6 +127,7 @@ The configuration for the application image that is built and deployed is config
 The configuration to build the application image is configured in a `build` section.
 
 If the application image has been built by another mechanism, you can skip the building part of the Helm Chart by setting the `build.enabled` field to `false`.
+If you are not deploying on OpenShift then as OpenShift S2I isn't supported then the image can't be built, thus even if `build.enabled` field is set to `true` the building part of the Helm Chart won't be triggered.
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |

--- a/charts/wildfly/templates/buildconfig-bootable-jar.yaml
+++ b/charts/wildfly/templates/buildconfig-bootable-jar.yaml
@@ -1,3 +1,3 @@
-{{- if and .Values.build.enabled (eq .Values.build.mode "bootable-jar") }}
+{{- if and (.Capabilities.APIVersions.Has "build.openshift.io/v1") (and .Values.build.enabled (eq .Values.build.mode "bootable-jar")) }}
 {{- include "wildfly-common.buildconfig-bootable-jar" (list . "wildfly.metadata.labels") -}}
 {{- end }}

--- a/charts/wildfly/templates/buildconfig-s2i-build-artifacts.yaml
+++ b/charts/wildfly/templates/buildconfig-s2i-build-artifacts.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.build.enabled (eq .Values.build.mode "s2i") }}
+{{- if and (.Capabilities.APIVersions.Has "build.openshift.io/v1") (and .Values.build.enabled (eq .Values.build.mode "s2i")) }}
 {{- include "wildfly-common.buildconfig-s2i-build-artifacts" (list . "wildfly.buildconfig-s2i-build-artifacts") -}}
 {{- end -}}
 

--- a/charts/wildfly/templates/buildconfig-s2i.yaml
+++ b/charts/wildfly/templates/buildconfig-s2i.yaml
@@ -1,4 +1,5 @@
-{{- if (and .Values.build.enabled (and (eq .Values.build.mode "s2i") .Values.build.s2i.buildApplicationImage)) }}
+
+{{- if and (.Capabilities.APIVersions.Has "build.openshift.io/v1") (and .Values.build.enabled (and (eq .Values.build.mode "s2i") .Values.build.s2i.buildApplicationImage)) }}
 {{- include "wildfly-common.buildconfig-s2i" (list . "wildfly.buildconfig-s2i") -}}
 {{- end -}}
 

--- a/charts/wildfly/templates/imagestream.yaml
+++ b/charts/wildfly/templates/imagestream.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag") -}}
+{{- if and (.Capabilities.APIVersions.Has "image.openshift.io/v1") (and (.Capabilities.APIVersions.Has "build.openshift.io/v1") (and .Values.build.enabled (eq .Values.build.output.kind "ImageStreamTag"))) -}}
 
 {{- if .Values.build.s2i.buildApplicationImage -}}
 {{- include "wildfly-common.imagestream" (list . "wildfly.metadata.labels") }}


### PR DESCRIPTION
 * Checking if "build.openshift.io/v1" is supported to create the build part / imagestreams

Issue: https://github.com/wildfly/wildfly-charts/issues/129