### PR TITLE
Bump wildfly to 2.4.0

### DIFF
--- a/charts/wildfly-common/Chart.yaml
+++ b/charts/wildfly-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: wildfly-common
 description: A library chart for WildFly-based applications
 type: library
-version: 2.1.1
+version: 2.2.0

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wildfly
 description: Build and Deploy WildFly applications on OpenShift
 type: "application"
-version: 2.3.2
+version: 2.4.0
 
 kubeVersion: ">= 1.19.0-0"
 home: https://wildfly.org
@@ -19,5 +19,5 @@ annotations:
 
 dependencies:
 - name: wildfly-common
-  version: 2.1.1
+  version: 2.2.0
   repository: file://../wildfly-common


### PR DESCRIPTION
and wildfly-common to 2.2.0 after the introduction of the `deploy.ingress` capability in #114