### PR TITLE
Fixing Nil Pointer Exception when using Ingress without TLS 

### DIFF
--- a/charts/wildfly-common/templates/_ingress.yaml
+++ b/charts/wildfly-common/templates/_ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {}
   annotations: {}
 spec:
-  {{- if .Values.deploy.ingress.className }}
+  {{- if (.Values.deploy.ingress).className }}
   ingressClassName: {{ .Values.deploy.ingress.className }}
   {{- end }}
   {{- include "wildfly-common.deployment.ingressSecret" . | nindent 2 -}}


### PR DESCRIPTION
Checking if the .Values.deploy.ingress.tls is defined before checking for .Values.deploy.ingress.tls.secret

Issue: https://github.com/wildfly/wildfly-charts/issues/135