### PR TITLE
Improvements for container bootstrap settings

### DIFF
--- a/charts/wildfly-common/templates/_deployment.yaml
+++ b/charts/wildfly-common/templates/_deployment.yaml
@@ -50,6 +50,15 @@ spec:
       containers:
         - name: {{ include "wildfly-common.appName" . }}
           image: {{ include "wildfly-common.appImage" . }}
+          {{- if .Values.deploy.argsOverride }}
+          args: {{- toYaml .Values.deploy.argsOverride | nindent 12 }}
+          {{- end }}
+          {{- if .Values.deploy.commandOverride }}
+          command: {{- toYaml .Values.deploy.commandOverride | nindent 12 }}
+          {{- end }}
+          {{- if .Values.deploy.securityContext }}
+          securityContext: {{- toYaml .Values.deploy.securityContext | nindent 12 }}
+          {{- end }}
           imagePullPolicy: Always
           ports:
           - name: jolokia

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -175,6 +175,8 @@ If the Helm chart is only used to build the application image, you can skip the 
 | ----- | ----------- | ------- | ---------------------- |
 | `deploy.annotations` | Map of `string` annotations that are applied to the deployment and its pod's `template` | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
 | `deploy.enabled` | Determines if deployment-related resources should be created. | `true` | Set this to `false` if you do not want to deploy an application image built by this chart. |
+| `deploy.argsOverride` | An `args` array to override the default arguments of the container's command. | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#changing-commands-and-arguments-that-are-run-in-a-container). |
+| `deploy.commandOverride` | A `command` array to override the default command of the container.  | -  | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#changing-commands-and-arguments-that-are-run-in-a-container). |
 | `deploy.env` | Freeform `env` items | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/).  These environment variables will be used when the application is _running_. If you need to specify environment variables when the application is built, use `build.env` instead. |
 | `deploy.envFrom` | Freeform `envFrom` items | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/).  These environment variables will be used when the application is _running_. If you need to specify environment variables when the application is built, use `build.envFrom` instead. |
 | `deploy.extraContainers` | Freeform extra `containers` items | - | [Kubernetes Documentation](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates) |
@@ -205,3 +207,4 @@ If the Helm chart is only used to build the application image, you can skip the 
 
 NOTE: Configuring a `route` and an `ingress` are exclusive. If both are enabled and you are deploying on Openshift then a `route` will be created. If you are deploying on Kubernetes then an `ingress` will be created.
 
+The template provide also an `extraObjects`, which is a free-form set of additional Kubernetes manifests that will be deployed alongside with the Application. A typical example is to create a PVC that will be later mounted to the container as a single deployment unit.

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -69,6 +69,40 @@ build:
   enabled: false
 ```
 
+## Using a Pre-built WildFly Image
+
+You can deploy the official [WildFly container image](https://quay.io/repository/wildfly/wildfly) directly, without building from source. Use `deploy.commandOverride` and `deploy.argsOverride` to customize how the WildFly server starts.
+
+For example, to expose the management interface on all network interfaces:
+
+```yaml
+image:
+  name: quay.io/wildfly/wildfly
+  tag: latest
+build:
+  enabled: false
+deploy:
+  argsOverride:
+    - "/opt/jboss/wildfly/bin/standalone.sh"
+    - "-b"
+    - "0.0.0.0"
+    - "-bmanagement"
+    - "0.0.0.0"
+  route:
+    enabled: false
+```
+
+You can also override the container command entirely:
+
+```yaml
+deploy:
+  commandOverride:
+    - "/bin/sh"
+    - "-c"
+  argsOverride:
+    - "/opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0"
+```
+
 ## Working With Private Image Registries
 
 If you are using private image registries to build, push or pull the application image, you need first to create secrets that will allow the container platform where the Helm Chart is deployed to authenticate against the private image registries.
@@ -192,8 +226,9 @@ If the Helm chart is only used to build the application image, you can skip the 
 | `deploy.labels` | Map of `string` labels that are applied to the deployment and its pod's `template` | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) |
 | `deploy.livenessProbe` | Freeform `livenessProbe` field. | HTTP Get on `<ip>:admin/health/live` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
 | `deploy.readinessProbe` | Freeform `readinessProbe` field. | HTTP Get on `<ip>:admin/health/ready` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
-| `deploy.replicas` | Number of pod replicas to deploy. | `1` | [Kubernetes Documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas) | 
+| `deploy.replicas` | Number of pod replicas to deploy. | `1` | [Kubernetes Documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas) |
 | `deploy.resources` | Freeform `resources` items | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| `deploy.securityContext` | Freeform security context for the pod. | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | `deploy.route` | Configuration specific to the creation of a `Route` resource to expose the application | - | - |
 | `deploy.route.enabled` | Determines if a `Route` should be created | `true` | Allows clients outside of OpenShift to access your application |
 | `deploy.route.host` | `host` is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen | - | [OKD Documentation](https://docs.okd.io/latest/networking/routes/route-configuration.html) |

--- a/charts/wildfly/README.md
+++ b/charts/wildfly/README.md
@@ -228,7 +228,7 @@ If the Helm chart is only used to build the application image, you can skip the 
 | `deploy.readinessProbe` | Freeform `readinessProbe` field. | HTTP Get on `<ip>:admin/health/ready` | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
 | `deploy.replicas` | Number of pod replicas to deploy. | `1` | [Kubernetes Documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas) |
 | `deploy.resources` | Freeform `resources` items | - | [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| `deploy.securityContext` | Freeform security context for the pod. | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| `deploy.securityContext` | Freeform security context for the container. | - | [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | `deploy.route` | Configuration specific to the creation of a `Route` resource to expose the application | - | - |
 | `deploy.route.enabled` | Determines if a `Route` should be created | `true` | Allows clients outside of OpenShift to access your application |
 | `deploy.route.host` | `host` is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen | - | [OKD Documentation](https://docs.okd.io/latest/networking/routes/route-configuration.html) |
@@ -242,4 +242,10 @@ If the Helm chart is only used to build the application image, you can skip the 
 
 NOTE: Configuring a `route` and an `ingress` are exclusive. If both are enabled and you are deploying on Openshift then a `route` will be created. If you are deploying on Kubernetes then an `ingress` will be created.
 
-The template provide also an `extraObjects`, which is a free-form set of additional Kubernetes manifests that will be deployed alongside with the Application. A typical example is to create a PVC that will be later mounted to the container as a single deployment unit.
+The chart also provides `extraObjects`, which is a free-form set of additional Kubernetes manifests that will be deployed alongside the application. A typical example is to create a PVC that will be later mounted to the container as a single deployment unit.
+
+### Extra Objects
+
+| Value | Description | Default | Additional Information |
+| ----- | ----------- | ------- | ---------------------- |
+| `extraObjects` | Defines additional Kubernetes resources required to deploy WildFly (e.g. PVC, secrets, configmaps). | `[]` | Each item is a complete Kubernetes resource definition that will be deployed alongside the application. |

--- a/charts/wildfly/templates/extra-objects.yaml
+++ b/charts/wildfly/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -593,6 +593,38 @@
                     }
                   }
                 },
+                "commandOverride": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Override the default command for the WildFly container."
+                },
+                "argsOverride": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Override the default args for the WildFly container."
+                },
+                "securityContext": {
+                  "description": "Security options the pod should run with.",
+                  "type": "object",
+                  "properties": {
+                    "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.",
+                      "type": "boolean"
+                    },
+                    "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a Pod.",
+                      "type": "integer"
+                    }
+                  }
+                },
                 "livenessProbe": {
                     "description": "Freeform livenessProbe configuration"
                 },
@@ -659,6 +691,15 @@
                   }
                 }
             }
+        },
+        "extraObjects": {
+          "type": "array",
+          "description": "Defines additional Kubernetes resources to be created.",
+          "items": {
+            "type": "object",
+            "description": "A generic Kubernetes resource definition.",
+            "additionalProperties": true
+          }
         }
     }
 }

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -608,7 +608,7 @@
                   "description": "Override the default args for the WildFly container."
                 },
                 "securityContext": {
-                  "description": "Freeform security context for the pod. More information: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+                  "description": "Freeform security context for the container. More information: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
                 },
                 "livenessProbe": {
                     "description": "Freeform livenessProbe configuration"

--- a/charts/wildfly/values.schema.json
+++ b/charts/wildfly/values.schema.json
@@ -608,22 +608,7 @@
                   "description": "Override the default args for the WildFly container."
                 },
                 "securityContext": {
-                  "description": "Security options the pod should run with.",
-                  "type": "object",
-                  "properties": {
-                    "runAsUser": {
-                      "description": "The UID to run the entrypoint of the container process.",
-                      "type": "integer"
-                    },
-                    "runAsNonRoot": {
-                      "description": "Indicates that the container must run as a non-root user.",
-                      "type": "boolean"
-                    },
-                    "fsGroup": {
-                      "description": "A special supplemental group that applies to all containers in a Pod.",
-                      "type": "integer"
-                    }
-                  }
+                  "description": "Freeform security context for the pod. More information: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
                 },
                 "livenessProbe": {
                     "description": "Freeform livenessProbe configuration"
@@ -694,10 +679,10 @@
         },
         "extraObjects": {
           "type": "array",
-          "description": "Defines additional Kubernetes resources to be created.",
+          "description": "Defines additional Kubernetes resources required to deploy WildFly (e.g. PVC, secrets, configmaps).",
           "items": {
             "type": "object",
-            "description": "A generic Kubernetes resource definition.",
+            "description": "A Kubernetes resource definition required for the WildFly deployment.",
             "additionalProperties": true
           }
         }


### PR DESCRIPTION
This Pull Request addresses issues described in https://github.com/wildfly/wildfly-charts/issues/142 and also adds a few more capabilities to the Helm Chart:

- `argsOverride` and `commandOverride` enable the user to override container Entrypoint and CMD respectfully
- `securityContext` enable overriding SecurityContext, which is specifically useful when we mount additional volumes to the WildFly Pod. When running on vanilla Kube, we quite often need  to specify the `fsGroup`. Another useful example is when dealing with hardened WildFly images such as IronBank. In these cases we need to ensure the `fsGroup` and `runAsUser` have the same value.
- `extraObjects` - enables a user to include extra Kubernetes Manifests into the deployment. This is useful when we'd like to create a PVC and mount it into the WildFly Pod right away. In such case I can do just this:

```
deploy:
 [...]
  volumes:
    - name: wildfly-deployment
      persistentVolumeClaim:
        claimName: wildfly-deployment
  volumeMounts:
    - name: wildfly-deployment
      mountPath: /opt/jboss/wildfly/standalone/deployments
extraObjects:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: wildfly-deployment
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 500Mi
```

With all the above setting I could use the basic WildFly image `quay.io/wildfly/wildfly`, which is quite an interesting use case after all. If you'd like, I can describe the procedure how to do it in the docs as a separate Pull Request. 

Fixes https://github.com/wildfly/wildfly-charts/issues/142